### PR TITLE
Links and edit

### DIFF
--- a/packages/ogma-annotations/src/Editor/Texts/index.ts
+++ b/packages/ogma-annotations/src/Editor/Texts/index.ts
@@ -219,7 +219,7 @@ export class Texts extends Editor<Text> {
     this.draggedHandle = NONE;
   };
 
-  private _onMousedown = (evt) => {
+  private _onMousedown = (evt: MouseEvent) => {
     evt.stopPropagation();
   };
 

--- a/packages/ogma-annotations/src/Editor/Texts/index.ts
+++ b/packages/ogma-annotations/src/Editor/Texts/index.ts
@@ -68,7 +68,7 @@ export class Texts extends Editor<Text> {
     <span class="handle left top point-handle top-left" data-handle-id="5"></span>
     <span class="handle bottom right point-handle bottom-right" data-handle-id="6"></span>
     <span class="handle left bottom left-handle point-handle bottom-left" data-handle-id="7"></span>
-    <textarea wrap="off"></textarea>
+    <textarea wrap="on"></textarea>
     </div>
   `
     );
@@ -84,6 +84,7 @@ export class Texts extends Editor<Text> {
     textArea.addEventListener('input', this._onInput);
     textArea.addEventListener('focus', this._onFocus);
     textArea.addEventListener('blur', this._onBlur);
+    textArea.addEventListener('mousedown', this._onMousedown);
     textArea.spellcheck = false;
 
     this.handles = Array.prototype.slice.call(
@@ -216,6 +217,10 @@ export class Texts extends Editor<Text> {
     this.emit(EVT_DRAG_END, this.annotation);
     this.isDragging = false;
     this.draggedHandle = NONE;
+  };
+
+  private _onMousedown = (evt) => {
+    evt.stopPropagation();
   };
 
   private onViewChanged = () => {

--- a/packages/ogma-annotations/src/Editor/Texts/render.ts
+++ b/packages/ogma-annotations/src/Editor/Texts/render.ts
@@ -5,12 +5,8 @@ import { getTextSize } from '../../utils';
 function removeElipse(str: string): string {
   return str.replace(/…$/, '');
 }
-function isText(e) {
-  return !!e.children[0]
-    && e.children[0].tagName === 'tspan';
-}
 
-function getText(e) {
+function getText(e: Element) {
   return e.children[0].innerHTML;
 }
 /**
@@ -71,7 +67,8 @@ export default function draw(annotation: Text, g: SVGGElement) {
     let query = l;
     const toReplace = [];
     while (query.length > 0) {
-      const start = children.find(e => isText(e)
+      const start = children.find(e => !!e.children[0]
+        && e.children[0].tagName === 'tspan'
         && query.startsWith(removeElipse(getText(e))));
       if (!start) break;
       toReplace.push(start);

--- a/packages/ogma-annotations/src/Editor/Texts/render.ts
+++ b/packages/ogma-annotations/src/Editor/Texts/render.ts
@@ -2,6 +2,9 @@ import Textbox from '@borgar/textbox';
 import { Text } from '../../types';
 import { getTextSize } from '../../utils';
 
+function removeElipse(str: string): string {
+  return str.replace(/…$/, '');
+}
 /**
  * @function draw
  * @param annotation the annotation to draw
@@ -24,13 +27,41 @@ export default function draw(annotation: Text, g: SVGGElement) {
     parser: 'html',
     createElement: Textbox.createElement
   });
+  box.overflowWrap('break-word');
 
   const lines = box.linebreak(
     annotation.properties.content.replaceAll('\n', '<br>')
   );
+  const matches = annotation.properties.content.match(/(https?:\/\/.*)/gm);
+  const links = matches ? matches.map(match => match.split(' ')[0]) : [];
   // Destination canvas is set to the height of the output
   const text = lines.render();
-
+  // replace spans with links: 
   text.setAttribute('transform', `translate(${padding}, ${padding})`);
+
+  const children = [...text.children];
+  links.forEach(l => {
+    let query = l;
+    const toReplace = [];
+    while (query.length > 0) {
+      const start = children.find(e => e.children[0]
+        && e.children[0].tagName === 'tspan'
+        && query.startsWith(removeElipse(e.children[0].innerHTML)));
+      if (!start) break;
+      toReplace.push(start);
+      query = query.slice(removeElipse(start.children[0].innerHTML).length);
+    }
+
+    toReplace.forEach(e => {
+      const link = document.createElementNS('http://www.w3.org/2000/svg', 'a');
+      link.setAttribute('href', l);
+      link.setAttribute('target', '_blank');
+      link.innerHTML = e.children[0].innerHTML;
+      e.children[0].innerHTML = '';
+      e.children[0].appendChild(link);
+    });
+
+  });
+
   g.appendChild(text);
 }

--- a/packages/ogma-annotations/src/Editor/base.ts
+++ b/packages/ogma-annotations/src/Editor/base.ts
@@ -88,6 +88,7 @@ export default abstract class Editor<
     evt: MouseButtonEvent<unknown, unknown> & MouseMoveEvent
   ) => {
     if (!evt.domEvent || this.isDragging || !this.shouldDetect) return;
+    // @ts-ignore
     if (evt.domEvent.type !== 'mousemove' && evt.domEvent.target.tagName === 'a') {
       return;
     }

--- a/packages/ogma-annotations/src/Editor/base.ts
+++ b/packages/ogma-annotations/src/Editor/base.ts
@@ -88,6 +88,9 @@ export default abstract class Editor<
     evt: MouseButtonEvent<unknown, unknown> & MouseMoveEvent
   ) => {
     if (!evt.domEvent || this.isDragging || !this.shouldDetect) return;
+    if (evt.domEvent.type !== 'mousemove' && evt.domEvent.target.tagName === 'a') {
+      return;
+    }
     const point = this.ogma.view.screenToGraphCoordinates(evt);
 
     // try to detect annotation

--- a/packages/ogma-annotations/src/style.css
+++ b/packages/ogma-annotations/src/style.css
@@ -171,3 +171,12 @@ svg text {
 .annotation-text:hover > rect {
   stroke: var(--handle-color);
 }
+
+.annotation-text a {
+  stroke: var(--handle-color);
+}
+
+.annotation-text a:hover {
+  stroke: var(--handle-color);
+  text-decoration: underline;
+}


### PR DESCRIPTION
 
- allow clickable links in the annotations
- Allow text selection within the annotation with the mouse
- Prevent from text overflow when a line contains no space 

https://github.com/Linkurious/ogma-annotations-control/assets/7451806/17af7e42-98d4-440b-9004-78885361b355

