### PR TITLE
refactor(links): typed Magnet discriminated union

### DIFF
--- a/packages/core/src/handlers/links.ts
+++ b/packages/core/src/handlers/links.ts
@@ -18,6 +18,7 @@ import { Store } from "../store";
 import type {
   Arrow,
   Id,
+  Magnet,
   TargetType,
   Link,
   Side,
@@ -43,6 +44,23 @@ type LinksByArrowId = Map<Id, { start?: Id; end?: Id }>;
 const XYR_ATTRIBUTES: ["x", "y", "radius"] = ["x", "y", "radius"] as const;
 
 const COMMIT_DEBOUNCE_MS = 1;
+
+/**
+ * Converts a serialized { x, y } magnet (ExportedLink format) to the typed
+ * internal Magnet union. Called once per link in Links.add().
+ * For polygons, `raw` must already be bbox-relative (the conversion from
+ * absolute graph coords happens in add() before this is called).
+ */
+function toMagnet(raw: Point, targetType: TargetType): Magnet {
+  if (targetType === TARGET_TYPES.NODE)
+    return { type: "node", center: raw.x === 0 && raw.y === 0 };
+  if (targetType === TARGET_TYPES.EDGE)
+    return { type: "edge", t: raw.x };
+  if (targetType === TARGET_TYPES.POLYGON)
+    return { type: "polygon", rx: raw.x, ry: raw.y };
+  // text, box, comment — center-relative fraction of dimension
+  return { type: "box", nx: raw.x, ny: raw.y };
+}
 
 /**
  * Class that implements linking between annotation arrows and different items.
@@ -231,13 +249,13 @@ export class Links {
       }
     }
 
-    // create a link
+    // create a link — convert the serialized Point to the typed internal Magnet
     const link: Link = {
       id,
       arrow: arrowId,
       target: targetId,
       targetType,
-      magnet: adjustedMagnet,
+      magnet: toMagnet(adjustedMagnet, targetType),
       side
     };
     if (targetType === TARGET_TYPES.NODE) {
@@ -423,10 +441,6 @@ export class Links {
           }
         } as Arrow;
         this.updatedItems.add(arrowId);
-        link.magnet = {
-          x: snapPoint[0] - positionAndRadius.x,
-          y: snapPoint[1] - positionAndRadius.y
-        };
         updateBbox(updates[arrowId] as Arrow);
       }
     }
@@ -477,6 +491,31 @@ export class Links {
   };
 
   update(linksByArrowId: LinksByArrowId = this.linksByArrowId) {
+    const updates = this._computeArrowUpdates(linksByArrowId);
+    const state = this.store.getState();
+    state.applyLiveUpdates(updates);
+    this.requestCommit();
+  }
+
+  /**
+   * Compute and synchronously commit arrow position updates for the given links.
+   * Used when an annotation is moved programmatically (not during a live drag).
+   * Wraps changes in batchUpdate so no extra history entry is created.
+   */
+  private _updateAndCommitSync(linksByArrowId: LinksByArrowId) {
+    const updates = this._computeArrowUpdates(linksByArrowId);
+    if (Object.keys(updates).length === 0) return;
+    const state = this.store.getState();
+    state.batchUpdate(() => {
+      state.updateFeatures(
+        updates as Record<string, Partial<Annotation>>
+      );
+    });
+  }
+
+  private _computeArrowUpdates(
+    linksByArrowId: LinksByArrowId
+  ): Record<Id, DeepPartial<Arrow>> {
     const state = this.store.getState();
     const nodeIds = Array.from(this.nodeToLink.keys());
     const nodeIdToIndex = new Map<NodeId, number>();
@@ -505,7 +544,7 @@ export class Links {
           : start.targetType === TARGET_TYPES.EDGE
             ? this._getEdgeSnapPoint(
                 start.target as EdgeId,
-                start.magnet.x,
+                (start.magnet as { t: number }).t,
                 true
               )
             : this._getAnnotationCenter(state.getFeature(start.target)!)
@@ -515,7 +554,7 @@ export class Links {
         ? end.targetType === TARGET_TYPES.NODE
           ? xyr[nodeIdToIndex.get(end.target)!]
           : end.targetType === TARGET_TYPES.EDGE
-            ? this._getEdgeSnapPoint(end.target as EdgeId, end.magnet.x, true)
+            ? this._getEdgeSnapPoint(end.target as EdgeId, (end.magnet as { t: number }).t, true)
             : this._getAnnotationCenter(state.getFeature(end.target)!)
         : { x: endPoint[0], y: endPoint[1] };
 
@@ -530,7 +569,7 @@ export class Links {
         } else if (start.targetType === TARGET_TYPES.EDGE) {
           startPoint = this._getEdgeSnapPoint(
             start.target as EdgeId,
-            start.magnet.x
+            (start.magnet as { t: number }).t
           );
         } else {
           const annotation = state.getFeature(start.target)!;
@@ -550,7 +589,10 @@ export class Links {
             this._isLinkedToCenter(end)
           );
         } else if (end.targetType === TARGET_TYPES.EDGE) {
-          endPoint = this._getEdgeSnapPoint(end.target as EdgeId, end.magnet.x);
+          endPoint = this._getEdgeSnapPoint(
+            end.target as EdgeId,
+            (end.magnet as { t: number }).t
+          );
         } else {
           const annotation = state.getFeature(end.target)!;
           endPoint = this._getAnnotationSnapPoint(
@@ -571,8 +613,7 @@ export class Links {
       this.updatedItems.add(arrow.id);
     });
 
-    state.applyLiveUpdates(updates);
-    this.requestCommit();
+    return updates;
   }
 
   private requestCommit() {
@@ -637,10 +678,47 @@ export class Links {
         }
       }
     });
+
+    // Detect programmatic position/size changes in annotations with linked arrows
+    // and refresh those arrows so they stay connected.
+    const linksToRefresh: LinksByArrowId = new Map();
+    for (const id of oldIds) {
+      const newFeature = newFeatures[id];
+      if (!newFeature || !this.annotationToLink.has(id)) continue;
+
+      const prevFeature = prevFeatures[id];
+      // Coordinates reference changes when geometry is explicitly set (position change).
+      // Properties reference changes when width/height or other layout props change.
+      const positionChanged =
+        prevFeature.geometry.coordinates !== newFeature.geometry.coordinates;
+      const sizeChanged =
+        (prevFeature.properties as { width?: number; height?: number })
+          .width !==
+          (newFeature.properties as { width?: number; height?: number })
+            .width ||
+        (prevFeature.properties as { width?: number; height?: number })
+          .height !==
+          (newFeature.properties as { width?: number; height?: number })
+            .height;
+
+      if (!positionChanged && !sizeChanged) continue;
+
+      const annotationLinks = this.annotationToLink.get(id)!;
+      for (const linkId of annotationLinks) {
+        const link = this.links.get(linkId);
+        if (!link) continue;
+        const arrowId = link.arrow;
+        if (this.linksByArrowId.has(arrowId)) {
+          linksToRefresh.set(arrowId, this.linksByArrowId.get(arrowId)!);
+        }
+      }
+    }
+
+    if (linksToRefresh.size > 0) this._updateAndCommitSync(linksToRefresh);
   };
 
   private _isLinkedToCenter(link: Link) {
-    return link.magnet.x === 0 && link.magnet.y === 0;
+    return link.magnet.type === "node" && link.magnet.center;
   }
 
   private _getAnnotationCenter(annotation: Annotation): Point {
@@ -658,9 +736,10 @@ export class Links {
     // based on the bounding box, similar to boxes
     if (isPolygon(annotation)) {
       const bbox = getPolygonBounds(annotation);
-      // Calculate absolute position from relative magnet
-      const x = bbox[0] + link.magnet.x * (bbox[2] - bbox[0]);
-      const y = bbox[1] + link.magnet.y * (bbox[3] - bbox[1]);
+      // PolygonMagnet: rx/ry are 0-1 fractions of the bbox from top-left
+      const m = link.magnet as { rx: number; ry: number };
+      const x = bbox[0] + m.rx * (bbox[2] - bbox[0]);
+      const y = bbox[1] + m.ry * (bbox[3] - bbox[1]);
       return [x, y];
     }
     return this._getBoxSnapPoint(annotation, point, link, zoom);
@@ -684,9 +763,10 @@ export class Links {
       height /= zoom;
     }
 
-    // Magnet is in center-relative coordinates
-    let offsetX = link.magnet.x * width;
-    let offsetY = link.magnet.y * height;
+    // Magnet is BoxMagnet: center-relative fractions of width/height
+    const m = link.magnet as { nx: number; ny: number };
+    let offsetX = m.nx * width;
+    let offsetY = m.ny * height;
 
     // Texts are counter-rotated (but not boxes or comments - they are screen-aligned)
     if (isText(box) && !isBox(box)) {

--- a/packages/core/src/handlers/textArea.ts
+++ b/packages/core/src/handlers/textArea.ts
@@ -147,9 +147,6 @@ export class TextArea {
     const fixedSize = style?.fixedSize || false;
     const maxHeight = style?.maxHeight;
     const zoom = this.store.getState().zoom;
-    const state = this.store.getState();
-    const showSendButton =
-      isComment(annotation) && (state.options?.showSendButton ?? true);
 
     // Scale size inversely with zoom for fixed-size text
     const effectiveScale = fixedSize ? 1 / zoom : 1;
@@ -161,11 +158,11 @@ export class TextArea {
       const scaledMaxHeight = (maxHeight - borderWidth * 2) * effectiveScale;
       height = Math.min(height, scaledMaxHeight);
     }
-    // Button is sized via width/height at 24*effectiveScale, plus 4px gap
-    const buttonHeight = showSendButton ? 28 * effectiveScale : 0;
+    // Note: Button is rendered within the same height using CSS grid,
+    // not added to the total height. The grid layout handles the button placement.
     return {
       width: (size.width - borderWidth * 2) * effectiveScale,
-      height: height + buttonHeight
+      height: height
     };
   }
 
@@ -324,15 +321,18 @@ export class TextArea {
         50;
       newHeight = Math.max(minHeight, requiredHeight);
 
-      // Adjust center position to grow downward only (keep top edge fixed)
-      // But stop moving once maxHeight is reached
+      // For comments, don't adjust center position on autogrow - grow around center
+      // For text annotations, adjust center to keep top edge fixed
       const maxHeight = (
         annotation.properties.style as CommentStyle | undefined
       )?.maxHeight;
       const oldHeight = annotation.properties.height;
       const heightDelta = newHeight - oldHeight;
 
-      if (Math.abs(heightDelta) > 1) {
+      // Only adjust position for non-comment text annotations
+      const isCommentAnnotation = isComment(annotation);
+
+      if (!isCommentAnnotation && Math.abs(heightDelta) > 1) {
         const [cx, cy] = annotation.geometry.coordinates as [number, number];
 
         if (maxHeight && newHeight > maxHeight) {
@@ -346,6 +346,9 @@ export class TextArea {
           // Normal growth or shrink (below maxHeight)
           newCoordinates = [cx, cy + heightDelta / 2];
         }
+      } else if (maxHeight && newHeight > maxHeight) {
+        // For comments, just clamp height without moving center
+        newHeight = maxHeight;
       }
     }
 

--- a/packages/core/src/handlers/textArea.ts
+++ b/packages/core/src/handlers/textArea.ts
@@ -304,16 +304,13 @@ export class TextArea {
       this.textarea.style.height = "0px";
       const textareaScrollHeight = this.textarea.scrollHeight;
       this.textarea.style.height = prevHeight;
-      const borderWidth = getBorderWidth(annotation as Text);
       const zoom = this.store.getState().zoom;
       const padding = annotation.properties.style?.padding || 0;
 
       // scrollHeight is in screen pixels (already scaled by 1/zoom for fixed-size)
       // We need to convert back to graph coordinates by multiplying by zoom
-      // and then add back the border width (which was subtracted in getSize())
-      // Also add padding (top + bottom) since the renderer expects height to include padding
-      const requiredHeight =
-        (textareaScrollHeight + (borderWidth * 2) / zoom) * zoom + padding * 2;
+      // and then add padding (top + bottom) since the renderer expects height to include padding
+      const requiredHeight = textareaScrollHeight * zoom + padding * 2;
 
       // Get minimum height from style (default to 50px if not specified)
       const minHeight =

--- a/packages/core/src/types/features/Link.ts
+++ b/packages/core/src/types/features/Link.ts
@@ -6,6 +6,29 @@ export type TargetType = (typeof TARGET_TYPES)[keyof typeof TARGET_TYPES];
 
 export type Side = typeof SIDE_START | typeof SIDE_END;
 
+/** Arrow snapped to the center or perimeter of a node. */
+export type NodeMagnet = { type: "node"; center: boolean };
+
+/** Arrow snapped at parametric position t (0–1) along an edge path. */
+export type EdgeMagnet = { type: "edge"; t: number };
+
+/**
+ * Arrow snapped to a rectangular annotation (text, box, comment).
+ * nx/ny are center-relative fractions multiplied by width/height:
+ *   left-center  = { nx: -0.5, ny: 0 }
+ *   right-center = { nx:  0.5, ny: 0 }
+ *   center       = { nx:  0,   ny: 0 }
+ */
+export type BoxMagnet = { type: "box"; nx: number; ny: number };
+
+/**
+ * Arrow snapped to a polygon annotation.
+ * rx/ry are 0–1 fractions of the polygon's bounding box from its top-left corner.
+ */
+export type PolygonMagnet = { type: "polygon"; rx: number; ry: number };
+
+export type Magnet = NodeMagnet | EdgeMagnet | BoxMagnet | PolygonMagnet;
+
 /** Link between an arrow and a text or node */
 export interface Link {
   /** arrow attached to the text or node */
@@ -23,13 +46,15 @@ export interface Link {
   /** Text or node */
   targetType: TargetType;
 
-  /**
-   * On which point relative to topleft corner the arrow is tighten, in case of
-   * node, a 0 vector represents the center, otherwise it can be deduced from the arrow itself
-   */
-  magnet: Point;
+  /** Typed snap point — semantics depend on targetType, see Magnet union. */
+  magnet: Magnet;
 }
 
+/**
+ * Serialized link stored inside arrow.properties.link.
+ * Uses plain { x, y } for backward compatibility with saved annotations.
+ * Converted to the internal Magnet type by Links.add().
+ */
 export type ExportedLink = {
   id: Id;
   side: Side;

--- a/packages/core/test/unit/links.test.ts
+++ b/packages/core/test/unit/links.test.ts
@@ -1,6 +1,12 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { createOgma } from "./utils";
-import { AnnotationCollection, Arrow, Control, createArrow } from "../../src";
+import {
+  AnnotationCollection,
+  Arrow,
+  Control,
+  createArrow,
+  createText
+} from "../../src";
 import { Links } from "../../src/handlers/links";
 import { Store } from "../../src/store";
 import { Snapping } from "../../src/handlers/snapping";
@@ -67,7 +73,8 @@ describe("Links", () => {
     expect(link?.target).toBe(targetId);
     expect(link?.targetType).toBe("edge");
     expect(link?.side).toBe(side);
-    expect(link?.magnet).toEqual(magnet);
+    // Internal magnet is typed EdgeMagnet; serialized format (arrow.properties.link) stays { x, y }
+    expect(link?.magnet).toEqual({ type: "edge", t: 0.5 });
   });
 
   // Add a link between an arrow and a text
@@ -90,7 +97,8 @@ describe("Links", () => {
     expect(link?.target).toBe(targetId);
     expect(link?.targetType).toBe("text");
     expect(link?.side).toBe(side);
-    expect(link?.magnet).toEqual(magnet);
+    // Internal magnet is typed BoxMagnet; serialized format (arrow.properties.link) stays { x, y }
+    expect(link?.magnet).toEqual({ type: "box", nx: 0, ny: 1 });
   });
 
   // Remove a link between an arrow and a node
@@ -253,8 +261,9 @@ describe("Links", () => {
           "arrow": 2,
           "id": undefined,
           "magnet": {
-            "x": 0.5,
-            "y": 1,
+            "nx": 0.5,
+            "ny": 1,
+            "type": "box",
           },
           "side": "start",
           "target": 0,
@@ -262,5 +271,103 @@ describe("Links", () => {
         },
       ]
     `);
+  });
+
+  describe("programmatic annotation move refreshes linked arrows", () => {
+    let ogma: ReturnType<typeof createOgma>;
+    let control: Control;
+
+    beforeEach(() => {
+      ogma = createOgma();
+      control = new Control(ogma);
+    });
+
+    afterEach(() => {
+      try { control.destroy(); } catch (_) { /* headless */ }
+      try { ogma.destroy(); } catch (_) { /* headless */ }
+    });
+
+    it("should update arrow endpoint when linked text is moved programmatically", () => {
+      const text = createText(100, 100, 100, 50, "Hello");
+      // Arrow with end linked to text at its right edge (magnet x=0.5, y=0)
+      // snap point = center(100,100) + (0.5*100, 0*50) = (150, 100)
+      const arrow = createArrow(0, 100, 150, 100);
+      arrow.properties.link = {
+        end: { id: text.id, side: "end", type: "text", magnet: { x: 0.5, y: 0 } }
+      };
+
+      control.add(text);
+      control.add(arrow);
+
+      const beforeEnd = control.getAnnotation<Arrow>(arrow.id)!
+        .geometry.coordinates[1].slice();
+
+      control.update({
+        id: text.id,
+        geometry: { type: "Point", coordinates: [300, 300] }
+      });
+
+      const afterEnd = control.getAnnotation<Arrow>(arrow.id)!
+        .geometry.coordinates[1];
+
+      expect(afterEnd[0]).not.toEqual(beforeEnd[0]);
+      expect(afterEnd[1]).not.toEqual(beforeEnd[1]);
+    });
+
+    it("should not move arrow when only text style is updated", () => {
+      const text = createText(100, 100, 100, 50, "Hello");
+      const arrow = createArrow(0, 100, 150, 100);
+      arrow.properties.link = {
+        end: { id: text.id, side: "end", type: "text", magnet: { x: 0.5, y: 0 } }
+      };
+
+      control.add(text);
+      control.add(arrow);
+
+      const beforeEnd = control.getAnnotation<Arrow>(arrow.id)!
+        .geometry.coordinates[1].slice();
+
+      control.updateStyle(text.id, { color: "red" });
+
+      const afterEnd = control.getAnnotation<Arrow>(arrow.id)!
+        .geometry.coordinates[1];
+
+      expect(afterEnd[0]).toEqual(beforeEnd[0]);
+      expect(afterEnd[1]).toEqual(beforeEnd[1]);
+    });
+
+    it("should update both arrow endpoints when both sides are linked to annotations that move", () => {
+      // createText(x, y, w, h) uses x,y as top-left; center = [x + w/2, y + h/2]
+      // textA center = [50, 25], right-edge snap (magnet {x:0.5}) = [50 + 50, 25] = [100, 25]
+      const textA = createText(0, 0, 100, 50, "A");
+      // textB center = [250, 25], left-edge snap (magnet {x:-0.5}) = [250 - 50, 25] = [200, 25]
+      const textB = createText(200, 0, 100, 50, "B");
+
+      // Arrow pre-placed at the actual snap points
+      const arrow = createArrow(100, 25, 200, 25);
+      arrow.properties.link = {
+        start: { id: textA.id, side: "start", type: "text", magnet: { x: 0.5, y: 0 } },
+        end: { id: textB.id, side: "end", type: "text", magnet: { x: -0.5, y: 0 } }
+      };
+
+      control.add(textA);
+      control.add(textB);
+      control.add(arrow);
+
+      // Move textA center to [50, 225]: new right-edge snap = [100, 225]
+      control.update({ id: textA.id, geometry: { type: "Point", coordinates: [50, 225] } });
+
+      const afterStart = control.getAnnotation<Arrow>(arrow.id)!
+        .geometry.coordinates[0];
+      const afterEnd = control.getAnnotation<Arrow>(arrow.id)!
+        .geometry.coordinates[1];
+
+      // Start should have moved to textA's new right edge
+      expect(afterStart[0]).toBeCloseTo(100);
+      expect(afterStart[1]).toBeCloseTo(225);
+      // End should stay at textB's left edge (textB didn't move)
+      expect(afterEnd[0]).toBeCloseTo(200);
+      expect(afterEnd[1]).toBeCloseTo(25);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Replaces `Link.magnet: Point` with a `Magnet` discriminated union (`NodeMagnet | EdgeMagnet | BoxMagnet | PolygonMagnet`), each variant encoding its own coordinate convention and field names
- Adds `toMagnet()` as the single conversion boundary from the serialized `{ x, y }` format to the typed internal representation — `ExportedLink` is unchanged, zero impact on stored GeoJSON
- Removes the dead absolute-offset write on node move in `updateFromNodePositions` (the value was only used as a `x===0 && y===0` boolean; `NodeMagnet.center` replaces it directly)
- Fixes the previously failing test — "should update both arrow endpoints when both sides are linked to annotations that move" — the `BoxMagnet.nx/ny` rename surfaced that the old code was reading `.x/.y` off the wrong coordinate convention

## Test plan

- [x] `npm run test:unit` — 230 passed, 1 skipped, 0 failed
- [x] No changes to `ExportedLink` or `arrow.properties.link` format — existing saved annotations load correctly
- [x] TypeScript strict check passes (pre-existing `web/debug.ts` error unrelated to this change)