### PR TITLE
fix(links): use collapsed dimensions for comment arrow endpoints

### DIFF
--- a/packages/core/src/handlers/links.ts
+++ b/packages/core/src/handlers/links.ts
@@ -24,9 +24,17 @@ import type {
   Side,
   Text,
   Annotation,
-  DeepPartial
+  DeepPartial,
+  Comment
 } from "../types";
-import { isBox, isText, isPolygon, isComment, isArrow } from "../types";
+import {
+  isBox,
+  isText,
+  isPolygon,
+  isComment,
+  isArrow,
+  getCommentSize
+} from "../types";
 import {
   getArrowSide,
   getBoxCenter,
@@ -752,7 +760,10 @@ export class Links {
     zoom: number
   ): [number, number] {
     const center = getBoxCenter(box);
-    let { width, height } = getBoxSize(box);
+    // Comments use getCommentSize so collapsed mode returns iconSize dimensions
+    let { width, height } = isComment(box)
+      ? getCommentSize(box as Comment)
+      : getBoxSize(box);
 
     // Handle fixedSize for Text and Comment (comments always have fixedSize)
     const hasFixedSize =

--- a/packages/core/src/handlers/links.ts
+++ b/packages/core/src/handlers/links.ts
@@ -580,7 +580,7 @@ export class Links {
             (start.magnet as { t: number }).t
           );
         } else {
-          const annotation = state.getFeature(start.target)!;
+          const annotation = state.getMergedFeature(start.target)!;
           startPoint = this._getAnnotationSnapPoint(
             annotation,
             endCenter,
@@ -602,7 +602,7 @@ export class Links {
             (end.magnet as { t: number }).t
           );
         } else {
-          const annotation = state.getFeature(end.target)!;
+          const annotation = state.getMergedFeature(end.target)!;
           endPoint = this._getAnnotationSnapPoint(
             annotation,
             startCenter,

--- a/packages/core/test/unit/links.test.ts
+++ b/packages/core/test/unit/links.test.ts
@@ -5,6 +5,7 @@ import {
   Arrow,
   Control,
   createArrow,
+  createComment,
   createText
 } from "../../src";
 import { Links } from "../../src/handlers/links";
@@ -368,6 +369,66 @@ describe("Links", () => {
       // End should stay at textB's left edge (textB didn't move)
       expect(afterEnd[0]).toBeCloseTo(200);
       expect(afterEnd[1]).toBeCloseTo(25);
+    });
+  });
+
+  describe("comment collapse updates linked arrow endpoint", () => {
+    let ogma: ReturnType<typeof createOgma>;
+    let control: Control;
+
+    beforeEach(() => {
+      ogma = createOgma();
+      control = new Control(ogma);
+    });
+
+    afterEach(() => {
+      try { control.destroy(); } catch (_) { /* headless */ }
+      try { ogma.destroy(); } catch (_) { /* headless */ }
+    });
+
+    it("should move arrow endpoint to icon edge when comment collapses", () => {
+      // Comment at (0,0), expanded: width=200, height=60, iconSize=32 (defaults)
+      // Right-edge snap with magnet {nx:0.5} at zoom=1:
+      //   expanded  → center(0,0) + 0.5 * 200 = (100, 0)
+      //   collapsed → center(0,0) + 0.5 *  32 = ( 16, 0)
+      const comment = createComment(0, 0, "review");
+      const arrow = createArrow(0, 0, 100, 0);
+      arrow.properties.link = {
+        end: {
+          id: comment.id,
+          side: "end",
+          type: "comment",
+          magnet: { x: 0.5, y: 0 }
+        }
+      };
+
+      control.add(comment);
+      control.add(arrow);
+
+      // Establish the initial snap (expanded): refresh writes to liveUpdates, commit flushes to features
+      // @ts-expect-error links is private
+      control.links.refresh();
+      // @ts-expect-error commit is private
+      control.links.commit();
+
+      const expandedEnd = control
+        .getAnnotation<Arrow>(arrow.id)!
+        .geometry.coordinates[1].slice();
+
+      control.toggleComment(comment.id);
+      // @ts-expect-error links is private
+      control.links.refresh();
+      // @ts-expect-error commit is private
+      control.links.commit();
+
+      const collapsedEnd = control
+        .getAnnotation<Arrow>(arrow.id)!
+        .geometry.coordinates[1];
+
+      // Endpoint should shift inward from the expanded right edge (100) to the icon right edge (16)
+      expect(expandedEnd[0]).toBeCloseTo(100);
+      expect(collapsedEnd[0]).toBeCloseTo(16);
+      expect(collapsedEnd[1]).toBeCloseTo(0);
     });
   });
 });


### PR DESCRIPTION
## Summary


<img width="607" height="262" alt="fix" src="https://github.com/user-attachments/assets/9b17ad24-7f5b-41b5-bfa0-e00ea4688f7e" />


When a comment collapses to its icon, `_getBoxSnapPoint` was still using `getBoxSize` which reads `properties.width`/`properties.height` (the expanded dimensions). This placed the arrow endpoint in empty space rather than on the icon.

`getCommentSize` already existed with the correct logic — returning `iconSize × iconSize` when collapsed and `properties.width × height` when expanded — but was never wired into the link snap calculation. This PR imports and calls it for comment annotations.

## Test plan

- [x] Open the demo with the "This group needs review" comment
- [x] Collapse the comment (click or zoom out past the threshold)
- [x] Verify the connected arrow endpoint snaps to the collapsed icon, not to empty space
- [x] Expand the comment again and verify the arrow endpoint returns to the correct position on the expanded box