### PR TITLE
fix(textarea): use scaled:false for fixedSize overlays to avoid font-size clamp

### DIFF
--- a/packages/core/src/handlers/textArea.ts
+++ b/packages/core/src/handlers/textArea.ts
@@ -127,7 +127,6 @@ export class TextArea {
     if (!annotation) return { x: 0, y: 0 };
 
     const style = annotation.properties.style as CommentStyle | undefined;
-    const fixedSize = style?.fixedSize || false;
     const maxHeight = style?.maxHeight;
     const zoom = this.store.getState().zoom;
     const borderWidth = getBorderWidth(annotation);
@@ -143,8 +142,9 @@ export class TextArea {
       height = Math.min(height, maxHeight);
     }
 
-    // For fixed-size, scale position to screen space
-    const scale = fixedSize ? 1 / zoom : 1;
+    // Use this.fixedSize (set in constructor from style + defaults) so comments
+    // without an explicit fixedSize in their style still get the correct scale.
+    const scale = this.fixedSize ? 1 / zoom : 1;
 
     // Calculate top-left corner from center
     return {
@@ -319,7 +319,12 @@ export class TextArea {
 
       // The overlay uses scaled:false so the textarea lives in screen-pixel space.
       // scrollHeight is already in the same units as properties.height — no zoom needed.
-      const requiredHeight = textareaScrollHeight + padding * 2;
+      // The send button (for comments) occupies a grid row inside the editor div, so its
+      // height must be included so the textarea isn't starved of vertical space.
+      const sendButtonHeight = this.sendButton
+        ? parseFloat(this.sendButton.style.height || "0")
+        : 0;
+      const requiredHeight = textareaScrollHeight + padding * 2 + sendButtonHeight;
 
       // Get minimum height from style (default to 50px if not specified)
       const minHeight =

--- a/packages/core/src/handlers/textArea.ts
+++ b/packages/core/src/handlers/textArea.ts
@@ -18,6 +18,7 @@ export class TextArea {
   private sendButton: HTMLButtonElement | null = null;
   public isFocused: boolean;
   private unsubscribe: () => void;
+  private fixedSize: boolean;
 
   constructor(
     private ogma: Ogma,
@@ -25,14 +26,25 @@ export class TextArea {
     private annotation: Id,
     private onSendHandler: () => void = () => {}
   ) {
-    const position = this.getPosition();
-    const size = this.getSize();
     const annotationData = this.getAnnotation()!;
     const state = this.store.getState();
     const showSendButton =
       isComment(annotationData) && (state.options?.showSendButton ?? true);
     const sendButtonIcon = state.options?.sendButtonIcon || "";
     const placeholderText = state.options?.textPlaceholder || "Enter text";
+
+    // Resolve fixedSize before getPosition/getSize since both read this.fixedSize.
+    // fixedSize overlays use scaled:false (screen-pixel space) to avoid the browser
+    // minimum-font-size trap: with scaled:true the CSS font becomes fontSize/zoom,
+    // browsers clamp that to ~10 px, then scale(zoom) blows it up.
+    const defaults = isComment(annotationData)
+      ? defaultCommentStyle
+      : defaultTextStyle;
+    this.fixedSize =
+      annotationData.properties.style?.fixedSize ?? defaults.fixedSize ?? false;
+
+    const position = this.getPosition();
+    const size = this.getSize();
 
     this.layer = this.ogma.layers.addOverlay(
       {
@@ -47,7 +59,10 @@ export class TextArea {
           }
         </div>`,
         position,
-        size
+        size,
+        // fixedSize annotations must not be scaled by Ogma's zoom transform.
+        // Non-fixedSize annotations live in graph space and scale naturally.
+        scaled: !this.fixedSize
       },
       LAYERS.EDITOR
     );
@@ -144,25 +159,22 @@ export class TextArea {
     const size = getBoxSize(annotation);
     const borderWidth = getBorderWidth(annotation as Text);
     const style = annotation.properties.style as CommentStyle | undefined;
-    const fixedSize = style?.fixedSize || false;
     const maxHeight = style?.maxHeight;
-    const zoom = this.store.getState().zoom;
 
-    // Scale size inversely with zoom for fixed-size text
-    const effectiveScale = fixedSize ? 1 / zoom : 1;
+    // With scaled:!fixedSize, Ogma handles all zoom compensation:
+    // - fixedSize (scaled:false): annotation dimensions are screen pixels, used as-is.
+    // - non-fixedSize (scaled:true): annotation dimensions are graph units, Ogma scales by zoom.
+    // In both cases the CSS size equals the annotation dimension directly.
+    let height = size.height - borderWidth * 2;
 
-    let height = (size.height - borderWidth * 2) * effectiveScale;
-
-    // Cap height at maxHeight if set (scaled for fixed-size)
     if (maxHeight) {
-      const scaledMaxHeight = (maxHeight - borderWidth * 2) * effectiveScale;
-      height = Math.min(height, scaledMaxHeight);
+      height = Math.min(height, maxHeight - borderWidth * 2);
     }
-    // Note: Button is rendered within the same height using CSS grid,
-    // not added to the total height. The grid layout handles the button placement.
+    // Button is rendered within the same height using CSS grid (1fr auto),
+    // not added to the total height.
     return {
-      width: (size.width - borderWidth * 2) * effectiveScale,
-      height: height
+      width: size.width - borderWidth * 2,
+      height
     };
   }
 
@@ -185,10 +197,10 @@ export class TextArea {
     } = annotation.properties.style || defaults;
     const textArea = this.textarea;
     const editorEl = this.layer.element as HTMLElement;
-    const zoom = this.store.getState().zoom;
 
-    // Scale font size inversely with zoom for fixed-size text
-    const effectiveScale = fixedSize ? 1 / zoom : 1;
+    // effectiveScale is 1 for both paths: fixedSize (scaled:false) uses screen pixels
+    // directly; non-fixedSize (scaled:true) passes graph units and Ogma applies zoom.
+    const effectiveScale = 1;
     const scaledFontSize = parseFloat(fontSize!.toString()) * effectiveScale;
     const scaledPadding = padding * effectiveScale;
 
@@ -216,7 +228,6 @@ export class TextArea {
 
     // Style the textarea
     const textAreaStyle = textArea.style;
-    textAreaStyle.font = `${scaledFontSize} ${font}`;
     textAreaStyle.fontFamily = font || "sans-serif";
     textAreaStyle.fontSize = `${scaledFontSize}px`;
     textAreaStyle.lineHeight = `${scaledFontSize * TEXT_LINE_HEIGHT}px`;
@@ -304,13 +315,11 @@ export class TextArea {
       this.textarea.style.height = "0px";
       const textareaScrollHeight = this.textarea.scrollHeight;
       this.textarea.style.height = prevHeight;
-      const zoom = this.store.getState().zoom;
       const padding = annotation.properties.style?.padding || 0;
 
-      // scrollHeight is in screen pixels (already scaled by 1/zoom for fixed-size)
-      // We need to convert back to graph coordinates by multiplying by zoom
-      // and then add padding (top + bottom) since the renderer expects height to include padding
-      const requiredHeight = textareaScrollHeight * zoom + padding * 2;
+      // The overlay uses scaled:false so the textarea lives in screen-pixel space.
+      // scrollHeight is already in the same units as properties.height — no zoom needed.
+      const requiredHeight = textareaScrollHeight + padding * 2;
 
       // Get minimum height from style (default to 50px if not specified)
       const minHeight =

--- a/packages/core/src/renderer/shapes/comment.ts
+++ b/packages/core/src/renderer/shapes/comment.ts
@@ -248,7 +248,6 @@ function renderExpandedBox(
   boxGroup: SVGGElement,
   comment: Comment,
   state: AnnotationState,
-  extraWidth: number = 0,
   showEditBtn: boolean = false
 ): void {
   const style = { ...defaultCommentStyle, ...comment.properties.style };
@@ -264,60 +263,29 @@ function renderExpandedBox(
     maxHeight
   } = style;
 
-  const maxWidth = comment.properties.width;
-  const content = comment.properties.content || "";
-  const numericFontSize =
-    typeof fontSize === "number" ? fontSize : parseFloat(fontSize);
-
-  // Calculate actual width needed based on content (+ extra for inline button)
-  // When selected and expandOnSelect is true, use full maxWidth; otherwise use content width
-  const contentWidth = measureTextWidth(
-    content,
-    font,
-    numericFontSize,
-    maxWidth,
-    padding
-  );
-  const isSelected = state.selectedFeatures.has(comment.id);
-  const shouldExpand = isSelected && style.expandOnSelect === true;
-  const actualWidth = shouldExpand ? maxWidth : contentWidth + extraWidth;
-
-  // Calculate height
+  // Always use the stored dimensions so the box never changes size on
+  // selection or edit — keeps the SVG and the textarea overlay in sync.
+  const actualWidth = comment.properties.width;
   const storedHeight = comment.properties.height;
-  const singleLine = isSingleLineContent(
-    content,
-    font,
-    numericFontSize,
-    maxWidth,
-    padding
-  );
-  const singleLineHeight = numericFontSize * TEXT_LINE_HEIGHT + padding * 2;
-  const effectiveHeight = singleLine
-    ? Math.min(storedHeight, singleLineHeight)
-    : storedHeight;
   const displayHeight = maxHeight
-    ? Math.min(effectiveHeight, maxHeight)
-    : effectiveHeight;
-  const needsScroll =
-    !singleLine && maxHeight ? storedHeight > maxHeight : false;
-
-  // Add extra height for edit button if shown (24px button + 4px gap)
-  const buttonHeight = showEditBtn ? 28 : 0;
-  const totalDisplayHeight = displayHeight + buttonHeight;
+    ? Math.min(storedHeight, maxHeight)
+    : storedHeight;
+  const needsScroll = maxHeight ? storedHeight > maxHeight : false;
+  const content = comment.properties.content || "";
 
   // Clear existing content
   boxGroup.innerHTML = "";
 
   // Center the box at (0,0) to align with the collapsed icon
   const x = -actualWidth / 2;
-  const y = -totalDisplayHeight / 2;
+  const y = -displayHeight / 2;
 
   // Create background rect
   const rect = createSVGElement<SVGRectElement>("rect");
   rect.setAttribute("x", `${x}`);
   rect.setAttribute("y", `${y}`);
   rect.setAttribute("width", `${actualWidth}`);
-  rect.setAttribute("height", `${totalDisplayHeight}`);
+  rect.setAttribute("height", `${displayHeight}`);
   rect.setAttribute("rx", `${borderRadius}`);
   rect.setAttribute("ry", `${borderRadius}`);
   rect.setAttribute(
@@ -336,7 +304,7 @@ function renderExpandedBox(
   foreignObject.setAttribute("x", `${x}`);
   foreignObject.setAttribute("y", `${y}`);
   foreignObject.setAttribute("width", `${actualWidth}`);
-  foreignObject.setAttribute("height", `${totalDisplayHeight}`);
+  foreignObject.setAttribute("height", `${displayHeight}`);
   foreignObject.style.pointerEvents = "none"; // Let clicks pass through to rect
 
   // Create the HTML content div
@@ -346,7 +314,7 @@ function renderExpandedBox(
   div.style.padding = `${padding}px`;
   div.style.boxSizing = "border-box";
   div.style.fontFamily = font;
-  div.style.fontSize = `${fontSize}px`;
+  div.style.fontSize = `${typeof fontSize === "number" ? fontSize : parseFloat(fontSize)}px`;
   div.style.lineHeight = `${(typeof fontSize === "number" ? fontSize : parseFloat(fontSize)) * TEXT_LINE_HEIGHT}px`;
   div.style.color = color;
   div.style.overflowY = needsScroll ? "auto" : "hidden";
@@ -354,32 +322,43 @@ function renderExpandedBox(
   div.style.overflowWrap = "break-word";
   div.style.whiteSpace = "pre-wrap";
   div.style.pointerEvents = "none"; // Let clicks pass through to rect
-  div.style.display = "flex";
-  div.style.flexDirection = "column";
-  div.style.position = "relative";
 
-  // Create text content container
-  const textDiv = document.createElement("div");
-  textDiv.style.flex = "1";
-  textDiv.style.minHeight = "0";
-  textDiv.style.overflowY = needsScroll ? "auto" : "hidden";
-  textDiv.innerHTML = formatContent(content);
-  div.appendChild(textDiv);
+  div.innerHTML = formatContent(content);
+  foreignObject.appendChild(div);
+  boxGroup.appendChild(foreignObject);
 
-  // Add edit button if needed (same structure as the send button)
+  // Edit button: a corner badge that sits inside the bottom-right of the
+  // box without adding to its dimensions. Clicking it triggers the same
+  // onClick path that opens the textarea editor.
   if (showEditBtn) {
-    const buttonDiv = document.createElement("div");
-    buttonDiv.classList.add("ogma-send-button");
-    buttonDiv.style.pointerEvents = "auto";
+    const btnSize = 24;
+    const btnMargin = 4;
+    const fo = createSVGElement<SVGForeignObjectElement>("foreignObject");
+    fo.setAttribute("x", `${x + actualWidth - btnSize - btnMargin}`);
+    fo.setAttribute("y", `${y + displayHeight - btnSize - btnMargin}`);
+    fo.setAttribute("width", `${btnSize}`);
+    fo.setAttribute("height", `${btnSize}`);
+
+    const btnDiv = document.createElement("div");
+    btnDiv.classList.add("ogma-send-button");
+    btnDiv.style.width = "100%";
+    btnDiv.style.height = "100%";
+    btnDiv.style.display = "flex";
+    btnDiv.style.alignItems = "center";
+    btnDiv.style.justifyContent = "center";
+    btnDiv.style.boxSizing = "border-box";
+    btnDiv.style.background = background;
+    btnDiv.style.border = `1px solid ${strokeColor || "#DDD"}`;
+    btnDiv.style.borderRadius = "4px";
+    btnDiv.style.pointerEvents = "auto";
+
     const iconSpan = document.createElement("span");
     iconSpan.classList.add("ogma-send-button-icon");
     iconSpan.innerHTML = state.options.editButtonIcon;
-    buttonDiv.appendChild(iconSpan);
-    div.appendChild(buttonDiv);
+    btnDiv.appendChild(iconSpan);
+    fo.appendChild(btnDiv);
+    boxGroup.appendChild(fo);
   }
-
-  foreignObject.appendChild(div);
-  boxGroup.appendChild(foreignObject);
 
   // Add drop shadow for comments (if enabled)
   if (style.shadow !== false) {
@@ -458,31 +437,9 @@ export function renderComment(
     state.editingFeature !== annotation.id &&
     state.options.showEditButton;
 
-  // Compute extra width for inline edit button on single-line comments
-  let extraWidth = 0;
-  if (showEditBtn) {
-    const cStyle = { ...defaultCommentStyle, ...annotation.properties.style };
-    const content = annotation.properties.content || "";
-    const numFS =
-      typeof cStyle.fontSize === "number"
-        ? cStyle.fontSize
-        : parseFloat((cStyle.fontSize || "12").toString());
-    if (
-      isSingleLineContent(
-        content,
-        cStyle.font || "Arial, sans-serif",
-        numFS,
-        annotation.properties.width,
-        cStyle.padding || 8
-      )
-    ) {
-      extraWidth = 32; // buttonSize (24) + margins (4*2)
-    }
-  }
-
   // Render both states
   renderCollapsedIcon(iconGroup, annotation, state);
-  renderExpandedBox(boxGroup, annotation, state, extraWidth, showEditBtn);
+  renderExpandedBox(boxGroup, annotation, state, showEditBtn);
 
   // Disable transitions if the comment was not visible (e.g., just came into view)
   if (!wasVisible) {


### PR DESCRIPTION
Replaces PR #102 with a clean single-commit fix.

<img width="934" height="604" alt="comments" src="https://github.com/user-attachments/assets/75275af1-0c48-4a5e-bd72-d2a380bb209c" />


## Problem

With Ogma's default `scaled:true`, fixedSize overlays compensate for zoom by setting CSS font-size to `fontSize/zoom`. At high zoom levels browsers clamp that to their minimum (~10–12 px), then Ogma's `scale(zoom)` transform blows it up to enormous screen sizes. Same issue affects padding and border-radius.

## Fix

Pass `scaled: !this.fixedSize` to `addOverlay`:

- **fixedSize = true** → `scaled: false` — the overlay lives in screen-pixel space. Ogma still converts the _position_ from graph to screen coordinates, but applies no zoom transform to the element itself. CSS values (`fontSize`, `padding`, etc.) are used directly as screen pixels — no `1/zoom` division needed anywhere.
- **fixedSize = false** → `scaled: true` — unchanged from before. Ogma applies `scale(zoom)` and CSS values in graph units scale correctly with the view.

Because `effectiveScale` is now `1` in both branches, it's inlined as a constant and `zoom` is no longer read in `getSize()` or `updateStyle()`.

The auto-grow height calculation in `updateContent()` also drops `* zoom`: with `scaled:false` the textarea's `scrollHeight` is already in screen pixels, the same unit as `properties.height` for fixedSize annotations.

## What was wrong with #102

- The `effectiveScale` for non-fixedSize was changed from `1` to `1/zoom`, which with `scaled:true` would make the overlay a constant screen size regardless of zoom — wrong for graph-space text boxes.
- `buttonHeight` was re-added to `getSize()`, conflicting with a fix already on develop.
- 15 commits including two merge commits, unrelated ESLint→oxlint changes, and debug tooling.

## Test plan
- [x] Open the demo and edit a comment (fixedSize=true) — box, font, and padding should render at the correct screen size at any zoom level
- [x] Edit a non-fixedSize text annotation — overlay should scale with graph zoom
- [x] Zoom to high levels (3×+) while editing a comment — font should not blow up
- [x] Auto-grow: type multiple lines in a comment — box should grow without zoom-dependent jump

Closes #102