### PR TITLE
feat(links): rigid-follow for 1:1 attached comments on node drag

### DIFF
--- a/packages/core/src/handlers/links.ts
+++ b/packages/core/src/handlers/links.ts
@@ -90,6 +90,7 @@ export class Links {
   private updatedItems = new Set<Id>();
   private onLinkCreated?: (arrow: Arrow, link: Link) => void;
   private commitTimeout!: ReturnType<typeof setTimeout>;
+  private nodePositionTimeout?: ReturnType<typeof setTimeout>;
 
   constructor(
     ogma: Ogma,
@@ -385,10 +386,17 @@ export class Links {
 
   private requestUpdateFromNodePositions(nodes: NodeList) {
     // debounce to next tick to get the real coordinates
-    setTimeout(() => this.updateFromNodePositions(nodes), 1);
+    clearTimeout(this.nodePositionTimeout);
+    this.nodePositionTimeout = setTimeout(
+      () => this.updateFromNodePositions(nodes),
+      1
+    );
   }
 
   private updateFromNodePositions(nodes: NodeList) {
+    // The debounced call can fire after the nodes (or the whole graph) have been
+    // removed; bail out rather than reading attributes off a destroyed list.
+    if (!nodes.size) return;
     const ids = nodes.getId();
     const links: LinksByArrowId = new Map();
     ids.forEach((id) => {
@@ -420,7 +428,7 @@ export class Links {
 
     const xyr = nodes.getAttributes(XYR_ATTRIBUTES) as XYR[];
     const state = this.store.getState();
-    const updates: Record<Id, DeepPartial<Arrow>> = {};
+    const updates: Record<Id, DeepPartial<Annotation>> = {};
     for (let i = 0; i < ids.length; i++) {
       const nodeId = ids[i];
       const nodeLinks = this.nodeToLink.get(nodeId);
@@ -433,6 +441,7 @@ export class Links {
         const coordinates = arrow.geometry.coordinates.slice();
         const end = getArrowSide(arrow, SIDE_END);
         const start = getArrowSide(arrow, SIDE_START);
+        const nodeSideIndex = link.side === SIDE_START ? 0 : 1;
 
         const positionAndRadius = xyr[i];
         // Update the arrow's position
@@ -441,7 +450,36 @@ export class Links {
           mul(subtract(end, start), -1),
           this._isLinkedToCenter(link)
         );
-        coordinates[link.side === SIDE_START ? 0 : 1] = snapPoint;
+
+        // Rigid-follow: when the arrow's *other* endpoint is attached 1:1 to a
+        // comment, dragging the node carries the whole callout (comment + arrow)
+        // by the node's delta instead of stretching the line. The arrow keeps
+        // its length and angle; the comment translates with the node.
+        const comment = this._getRigidFollowComment(arrowId, link);
+        if (comment) {
+          const oldNodePoint = coordinates[nodeSideIndex];
+          const delta = subtract(
+            { x: snapPoint[0], y: snapPoint[1] },
+            { x: oldNodePoint[0], y: oldNodePoint[1] }
+          );
+          coordinates[0] = [coordinates[0][0] + delta.x, coordinates[0][1] + delta.y];
+          coordinates[1] = [coordinates[1][0] + delta.x, coordinates[1][1] + delta.y];
+
+          const [cx, cy] = comment.geometry.coordinates as [number, number];
+          const commentUpdate: DeepPartial<Comment> = {
+            ...comment,
+            geometry: {
+              type: "Point",
+              coordinates: [cx + delta.x, cy + delta.y]
+            }
+          };
+          updates[comment.id] = commentUpdate as Annotation;
+          updateBbox(commentUpdate as Comment);
+          this.updatedItems.add(comment.id);
+        } else {
+          coordinates[nodeSideIndex] = snapPoint;
+        }
+
         updates[arrowId] = {
           ...arrow,
           geometry: {
@@ -729,6 +767,38 @@ export class Links {
     return link.magnet.type === "node" && link.magnet.center;
   }
 
+  /**
+   * Rigid-follow guard: returns the linked Comment when this arrow's *other*
+   * endpoint (relative to `nodeSideLink`) is attached to a comment that has
+   * exactly one inbound link. In that case a node drag should translate the
+   * whole callout (comment + arrow) rather than just moving the node-side
+   * endpoint. Returns undefined when the relationship isn't a clean 1:1
+   * node→arrow→comment chain.
+   */
+  private _getRigidFollowComment(
+    arrowId: Id,
+    nodeSideLink: Link
+  ): Comment | undefined {
+    const arrowLinks = this.linksByArrowId.get(arrowId);
+    if (!arrowLinks) return undefined;
+
+    // The far side is whichever end isn't the one anchored to the moved node.
+    const farLinkId =
+      nodeSideLink.side === SIDE_START ? arrowLinks.end : arrowLinks.start;
+    if (!farLinkId) return undefined;
+
+    const farLink = this.links.get(farLinkId);
+    if (!farLink || farLink.targetType !== TARGET_TYPES.COMMENT) return undefined;
+
+    // 1:1 only — the comment must not be the target of any other link.
+    const commentLinks = this.annotationToLink.get(farLink.target);
+    if (!commentLinks || commentLinks.size !== 1) return undefined;
+
+    const comment = this.store.getState().getFeature(farLink.target);
+    if (!comment || !isComment(comment)) return undefined;
+    return comment;
+  }
+
   private _getAnnotationCenter(annotation: Annotation): Point {
     if (isPolygon(annotation)) return getPolygonCenter(annotation);
     return getBoxCenter(annotation as Text);
@@ -861,6 +931,8 @@ export class Links {
   }
 
   public destroy() {
+    clearTimeout(this.commitTimeout);
+    clearTimeout(this.nodePositionTimeout);
     this.ogma.events.off(this.onSetMultipleAttributes);
   }
 }

--- a/packages/core/test/unit/links.test.ts
+++ b/packages/core/test/unit/links.test.ts
@@ -315,6 +315,33 @@ describe("Links", () => {
       expect(afterEnd[1]).not.toEqual(beforeEnd[1]);
     });
 
+    it("should update arrow endpoint when linked comment is moved programmatically", () => {
+      // Comment at (100,100), expanded default width=200; right-edge snap
+      // (magnet x=0.5, y=0) = center(100,100) + (0.5*200, 0) = (200, 100)
+      const comment = createComment(100, 100, "review");
+      const arrow = createArrow(0, 100, 200, 100);
+      arrow.properties.link = {
+        end: { id: comment.id, side: "end", type: "comment", magnet: { x: 0.5, y: 0 } }
+      };
+
+      control.add(comment);
+      control.add(arrow);
+
+      const beforeEnd = control.getAnnotation<Arrow>(arrow.id)!
+        .geometry.coordinates[1].slice();
+
+      control.update({
+        id: comment.id,
+        geometry: { type: "Point", coordinates: [300, 300] }
+      });
+
+      const afterEnd = control.getAnnotation<Arrow>(arrow.id)!
+        .geometry.coordinates[1];
+
+      expect(afterEnd[0]).not.toEqual(beforeEnd[0]);
+      expect(afterEnd[1]).not.toEqual(beforeEnd[1]);
+    });
+
     it("should not move arrow when only text style is updated", () => {
       const text = createText(100, 100, 100, 50, "Hello");
       const arrow = createArrow(0, 100, 150, 100);
@@ -429,6 +456,129 @@ describe("Links", () => {
       expect(expandedEnd[0]).toBeCloseTo(100);
       expect(collapsedEnd[0]).toBeCloseTo(16);
       expect(collapsedEnd[1]).toBeCloseTo(0);
+    });
+  });
+
+  describe("node drag rigidly moves a 1:1 attached comment", () => {
+    let ogma: ReturnType<typeof createOgma>;
+    let control: Control;
+
+    beforeEach(() => {
+      ogma = createOgma();
+      control = new Control(ogma);
+    });
+
+    afterEach(() => {
+      try { control.destroy(); } catch (_) { /* headless */ }
+      try { ogma.destroy(); } catch (_) { /* headless */ }
+    });
+
+    it("translates the comment and the whole arrow by the node's delta", () => {
+      ogma.addNode({ id: "node1", attributes: { x: 0, y: 0, radius: 0 } });
+
+      // Comment center at (200,0). Arrow from node center to comment left edge.
+      const comment = createComment(200, 0, "review");
+      const arrow = createArrow(0, 0, 100, 0);
+
+      control.add(comment);
+      control.add(arrow);
+
+      // start → node1 (center), end → comment left edge
+      // @ts-expect-error links is private
+      control.links.add(arrow, "start", "node1", "node", { x: 0, y: 0 });
+      // @ts-expect-error links is private
+      control.links.add(arrow, "end", comment.id, "comment", { x: -0.5, y: 0 });
+
+      // @ts-expect-error links is private
+      control.links.refresh();
+      // @ts-expect-error commit is private
+      control.links.commit();
+
+      const beforeStart = control.getAnnotation<Arrow>(arrow.id)!
+        .geometry.coordinates[0].slice();
+      const beforeEnd = control.getAnnotation<Arrow>(arrow.id)!
+        .geometry.coordinates[1].slice();
+      const beforeComment = (
+        control.getAnnotation(comment.id)!.geometry as { coordinates: number[] }
+      ).coordinates.slice();
+
+      // Drag node1 down by 100. setAttributes emits setMultipleAttributes,
+      // which the Links handler picks up; invoke the update path directly so the
+      // assertion doesn't depend on the internal debounce timer.
+      ogma.getNode("node1")!.setAttributes({ y: 100 });
+      // @ts-expect-error updateFromNodePositions is private (bypasses the setTimeout debounce)
+      control.links.updateFromNodePositions(ogma.getNodes(["node1"]));
+      // @ts-expect-error commit is private
+      control.links.commit();
+      // Cancel the debounced duplicate scheduled by setAttributes so it can't
+      // translate the comment a second time after the assertions.
+      // @ts-expect-error nodePositionTimeout is private
+      clearTimeout(control.links.nodePositionTimeout);
+
+      const afterStart = control.getAnnotation<Arrow>(arrow.id)!
+        .geometry.coordinates[0];
+      const afterEnd = control.getAnnotation<Arrow>(arrow.id)!
+        .geometry.coordinates[1];
+      const afterComment = (
+        control.getAnnotation(comment.id)!.geometry as { coordinates: number[] }
+      ).coordinates;
+
+      // The comment translates rigidly with the node (delta y ≈ +100, x unchanged).
+      expect(afterComment[0]).toBeCloseTo(beforeComment[0]);
+      expect(afterComment[1]).toBeCloseTo(beforeComment[1] + 100);
+
+      // Both arrow endpoints shift by the same delta → the line keeps its length
+      // and angle (no stretching).
+      expect(afterStart[0]).toBeCloseTo(beforeStart[0]);
+      expect(afterStart[1]).toBeCloseTo(beforeStart[1] + 100);
+      expect(afterEnd[0]).toBeCloseTo(beforeEnd[0]);
+      expect(afterEnd[1]).toBeCloseTo(beforeEnd[1] + 100);
+    });
+
+    it("does NOT rigidly move the comment when it has more than one inbound link", () => {
+      ogma.addNode({ id: "node1", attributes: { x: 0, y: 0, radius: 0 } });
+
+      const comment = createComment(200, 0, "review");
+      const arrow1 = createArrow(0, 0, 100, 0);
+      const arrow2 = createArrow(200, 200, 150, 0);
+
+      control.add(comment);
+      control.add(arrow1);
+      control.add(arrow2);
+
+      // arrow1: node1 → comment (the would-be rigid pair)
+      // @ts-expect-error links is private
+      control.links.add(arrow1, "start", "node1", "node", { x: 0, y: 0 });
+      // @ts-expect-error links is private
+      control.links.add(arrow1, "end", comment.id, "comment", { x: -0.5, y: 0 });
+      // arrow2 also targets the comment → it's no longer a 1:1 attachment.
+      // @ts-expect-error links is private
+      control.links.add(arrow2, "end", comment.id, "comment", { x: 0, y: 0.5 });
+
+      // @ts-expect-error links is private
+      control.links.refresh();
+      // @ts-expect-error commit is private
+      control.links.commit();
+
+      const beforeComment = (
+        control.getAnnotation(comment.id)!.geometry as { coordinates: number[] }
+      ).coordinates.slice();
+
+      ogma.getNode("node1")!.setAttributes({ y: 100 });
+      // @ts-expect-error updateFromNodePositions is private
+      control.links.updateFromNodePositions(ogma.getNodes(["node1"]));
+      // @ts-expect-error commit is private
+      control.links.commit();
+      // @ts-expect-error nodePositionTimeout is private
+      clearTimeout(control.links.nodePositionTimeout);
+
+      const afterComment = (
+        control.getAnnotation(comment.id)!.geometry as { coordinates: number[] }
+      ).coordinates;
+
+      // Comment must stay put — multi-link falls back to rubber-band.
+      expect(afterComment[0]).toBeCloseTo(beforeComment[0]);
+      expect(afterComment[1]).toBeCloseTo(beforeComment[1]);
     });
   });
 });


### PR DESCRIPTION
## What

When an arrow's far endpoint is attached **1:1** to a comment and the **node** on the near endpoint is dragged, the whole callout (comment + both arrow endpoints) now translates by the node's delta — instead of just moving the node-side endpoint and stretching the arrow.

The line keeps its length and angle, matching the attached-callout behavior in tools like Miro. This was a UX request: dragging a node a long way shouldn't leave a kilometer-long arrow trailing to a stationary comment.

### Behavior
- **1:1 node → arrow → comment**: drag the node → comment + arrow translate rigidly.
- **Anything else** (comment has >1 inbound link, or far side isn't a comment): unchanged rubber-band behavior — only the node-side endpoint follows.

## Also in this PR
Hardened the debounced node-position update path in `links.ts`:
- Guard against a stale/empty `NodeList` (the 1ms-debounced call can fire after nodes — or the whole graph — were destroyed, which previously threw).
- Track and clear the pending timer in `destroy()`.

## Tests
- linked comment moved programmatically refreshes the arrow endpoint
- node drag rigidly translates a 1:1 attached comment + the whole arrow
- negative case: a comment with a second inbound link stays put (rubber-band fallback)

All 18 links tests pass; full unit suite green; `tsc` clean.

## Base
Targets `refactor/replace-borgar-textbox-with-pretext` (#106) rather than `develop`, because that refactor isn't on `develop` yet and the tree doesn't build without it. Retarget to `develop` once #106 merges.

## Note
This adds logic to `links.ts`, which is slated for the magnet discriminated-union redesign (roadmap item #1). The change is localized and the guard helper is self-contained, so it should port cleanly.

