### PR TITLE
fix(react): correct dependency classification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -714,12 +714,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@date-fns/tz": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
-      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
-      "license": "MIT"
-    },
     "node_modules/@docsearch/css": {
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
@@ -1630,11 +1624,10 @@
       "link": true
     },
     "node_modules/@linkurious/ogma-react": {
-      "version": "5.1.15-develop.3",
-      "resolved": "https://nexus3.linkurious.net/repository/npm/@linkurious/ogma-react/-/ogma-react-5.1.15-develop.3.tgz",
-      "integrity": "sha512-4IJ18S0IriHmruW9aIiAUIG35E4BSdG5kRqRwE7hJQ4eWeIMsA1IJLG97JYWe92m27HQEeDcI2xwgFFPT6NhUg==",
+      "version": "5.1.15",
+      "resolved": "https://nexus3.linkurious.net/repository/npm/@linkurious/ogma-react/-/ogma-react-5.1.15.tgz",
+      "integrity": "sha512-xEFGQDKXBrcUNc+KQRLaON/+oG4f+BumqWgL3CUiv6SM5n3ddgBehAhU8P6erARLAUdyRE1JWV9zuKRnxnwV5g==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@linkurious/ogma": ">=5.3.9 || ^6.0.0",
         "react": ">=17.0.0",
@@ -4882,22 +4875,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
-    "node_modules/date-fns-jalali": {
-      "version": "4.1.0-0",
-      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
-      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
-      "license": "MIT"
     },
     "node_modules/de-indent": {
       "version": "1.0.2",
@@ -8478,27 +8455,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-day-picker": {
-      "version": "9.13.0",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.13.0.tgz",
-      "integrity": "sha512-euzj5Hlq+lOHqI53NiuNhCP8HWgsPf/bBAVijR50hNaY1XwjKjShAnIe8jm8RD2W9IJUvihDIZ+KrmqfFzNhFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@date-fns/tz": "^1.4.1",
-        "date-fns": "^4.1.0",
-        "date-fns-jalali": "^4.1.0-0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/gpbl"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -11273,7 +11229,8 @@
       "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "react-day-picker": "9.13.0"
+        "@linkurious/ogma-annotations": "2.1.0",
+        "@linkurious/ogma-react": "5.1.15"
       },
       "devDependencies": {
         "@linkurious/eslint-config-ogma": "2.1.0",
@@ -11297,8 +11254,6 @@
       },
       "peerDependencies": {
         "@linkurious/ogma": ">=5.3.11",
-        "@linkurious/ogma-annotations": "2.1.0",
-        "@linkurious/ogma-react": "5.1.15-develop.3",
         "react": ">=17"
       }
     },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "dev": "vite -c web/vite.config.mts",
     "build": "tsc --p ./tsconfig-build.json && vite build --mode production",
-    "postversion": "npm i --save-peer @linkurious/ogma-annotations@${npm_new_version}",
+    "postversion": "npm i --save @linkurious/ogma-annotations@${npm_new_version}",
     "bump:patch": "bump2version patch && npm version --no-git-tag-version patch",
     "bump:minor": "bump2version minor && npm version --no-git-tag-version minor",
     "bump:major": "bump2version major && npm version --no-git-tag-version major",
@@ -56,8 +56,6 @@
   "license": "Apache-2.0",
   "peerDependencies": {
     "@linkurious/ogma": ">=5.3.11",
-    "@linkurious/ogma-annotations": "2.1.0",
-    "@linkurious/ogma-react": "5.1.15-develop.3",
     "react": ">=17"
   },
   "devDependencies": {
@@ -81,6 +79,7 @@
     "vitest": "3.2.6"
   },
   "dependencies": {
-    "react-day-picker": "9.13.0"
+    "@linkurious/ogma-annotations": "2.1.0",
+    "@linkurious/ogma-react": "5.1.15"
   }
 }

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -41,6 +41,7 @@ export default defineConfig({
         globals: {
           "@linkurious/ogma": "Ogma",
           "@linkurious/ogma-react": "OgmaReact",
+          "@linkurious/ogma-annotations": "OgmaAnnotations",
           react: "React",
           "react-dom": "ReactDOM"
         }


### PR DESCRIPTION
## Summary

Fixes the dependency declarations in `@linkurious/ogma-annotations-react`.

- **Remove `react-day-picker`** — it was the *only* declared runtime dependency but is imported **nowhere** in the package (neither `src/` nor the demo). It was dead weight forced on every consumer.
- **Move `@linkurious/ogma-annotations` and `@linkurious/ogma-react` from `peerDependencies` → `dependencies`** — both are imported in published source (`index.ts`, `AnnotationsContext.tsx`, etc.), so consumers should receive them automatically rather than having to install them separately.
- **Keep `@linkurious/ogma` and `react` as `peerDependencies`** — host-provided singletons.
- **Update the `postversion` script** to `--save` (was `--save-peer`) so version bumps no longer re-add `ogma-annotations` as a peer and undo this fix.
- **Add `@linkurious/ogma-annotations` to the UMD `output.globals`** in the vite config to clear the build warning.

## Test plan

- [x] `npm install` updates the lockfile cleanly
- [x] `npm run build` succeeds with no warnings
- [x] `npm test` passes (10/10)